### PR TITLE
added System.Web as frameworkAssembly inside nuspec file

### DIFF
--- a/StackExchange.Exceptional/StackExchange.Exceptional.nuspec
+++ b/StackExchange.Exceptional/StackExchange.Exceptional.nuspec
@@ -13,6 +13,9 @@
         <language>en-US</language>
         <description>.Net Error handler for logging to SQL, JSON or Memory.</description>
         <summary>.Net Error handler used internally at Stack Exchange/Stack Overflow.  Primarily for logging all unhandled exceptions to SQL, but also supporting JSON and Memory based logging.</summary>
+        <frameworkAssemblies>
+          <frameworkAssembly assemblyName="System.Web"  />
+        </frameworkAssemblies>
     </metadata>
     <files>
         <file src="bin\Release\StackExchange.Exceptional.*" target="lib" />


### PR DESCRIPTION
Added System.Web as frameworkAssembly inside nuspec file so that the required System.Web would be referenced when the package is installed.
