### PR TITLE
Only call Linkify if the custom value isn't null.

### DIFF
--- a/StackExchange.Exceptional/Pages/ErrorInfo.cshtml
+++ b/StackExchange.Exceptional/Pages/ErrorInfo.cshtml
@@ -166,7 +166,14 @@ else
                         {
                             <tr>
                                 <td class="key">@cd</td>
-                                <td class="value">@Linkify(error.CustomData[cd])</td>
+                                @if (error.CustomData[cd].HasValue())
+                                {
+                                    <td class="value">@Linkify(error.CustomData[cd])</td>
+                                }
+                                else
+                                {
+                                    <td class="value"></td>
+                                }
                             </tr>
                         }
                     </table>


### PR DESCRIPTION
Currently null gets passed down to the `Regex` in `Linkify` which throws a null reference exception.
