### PR TITLE
Added ability to use custom error stores from config

### DIFF
--- a/Samples.MVC4/Web.config
+++ b/Samples.MVC4/Web.config
@@ -35,6 +35,8 @@
     <!--<Email fromAddress="exceptions@site.com" fromDisplayName="Bob the Builder" toAddress="nrcraver@gmail.com" />-->
     <!-- Which ErrorStore to use, if no element is declared here a Memory store with defaults will be used -->
     <ErrorStore type="Memory" />
+    <!-- You can use own store tpye by specifying assembly-qualified name (http://msdn.microsoft.com/en-us/library/system.type.assemblyqualifiedname.aspx)-->
+    <!--<ErrorStore type="StackExchange.Exceptional.AzureStore.AzureErrorStore, StackExchange.Exceptional.AzureStore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" connectionStringName="AzureBlobStorage" />-->
     <!-- Other store types, common attributes:
          - rollupSeconds: optional (default 600 seconds), determines how long the window is to roll up exceptions with the same stack trace - 0 to not roll up
          - backupQueueSize: optional (default 1000), determines how many errors to cache (excluding rollups) in memory when logging fails...every 2 seconds we'll retry logging and flush these out to the final store -->
@@ -45,6 +47,7 @@
     <!--<ErrorStore type="SQL" connectionStringName="MyConnectionString" />-->
   </Exceptional>
   <connectionStrings>
+    <add name="AzureBlobStorage" connectionString="DefaultEndpointsProtocol=https;AccountName=[you account name];AccountKey=[your account key]"/>
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=aspnet-Samples.MVC4-20120901082117;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\aspnet-Samples.MVC4-20120901082117.mdf" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>

--- a/StackExchange.Exceptional/ErrorStore.cs
+++ b/StackExchange.Exceptional/ErrorStore.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Exceptional
     public abstract partial class ErrorStore
     {
         private static ErrorStore _defaultStore;
-        
+
         [ThreadStatic]
         private static List<Regex> _ignoreRegex;
         [ThreadStatic]
@@ -44,7 +44,7 @@ namespace StackExchange.Exceptional
         /// The default number of seconds to roll up errors for.  Identical stack trace errors within 10 minutes get a DuplicateCount++ instead of a separate exception logged.
         /// </summary>
         public const int DefaultRollupSeconds = 600;
-        
+
         /// <summary>
         /// Base constructor of the error store to set common properties
         /// </summary>
@@ -73,7 +73,7 @@ namespace StackExchange.Exceptional
         /// Gets if this error store is 
         /// </summary>
         public bool InFailureMode { get { return _isInRetry; } }
-        
+
         /// <summary>
         /// The Rollup threshold within which errors logged rapidly are rolled up
         /// </summary>
@@ -152,7 +152,7 @@ namespace StackExchange.Exceptional
         /// Get the name of this error log store implementation.
         /// </summary>
         public virtual string Name { get { return GetType().Name; } }
-        
+
         private static string _applicationName { get; set; }
         /// <summary>
         /// Gets the name of the application to which the log is scoped.
@@ -195,7 +195,7 @@ namespace StackExchange.Exceptional
         {
             get { return _defaultStore ?? (_defaultStore = GetErrorStoreFromConfig()); }
         }
-        
+
         /// <summary>
         /// Sets the default error store to use for logging
         /// </summary>
@@ -259,7 +259,7 @@ namespace StackExchange.Exceptional
         public bool Protect(Guid guid)
         {
             if (_isInRetry) return false; // no protecting allowed when failing, since we don't respect it in the queue anyway
-            
+
             using (new TransactionScope(TransactionScopeOption.Suppress))
             {
                 return ProtectError(guid);
@@ -506,8 +506,8 @@ namespace StackExchange.Exceptional
             // a bit of validation
             if (settings.Type.IsNullOrEmpty())
                 throw new ArgumentOutOfRangeException("settings", "ErrorStore 'type' must be specified");
-            if (settings.Size < 1) 
-                throw new ArgumentOutOfRangeException("settings","ErrorStore 'size' must be positive");
+            if (settings.Size < 1)
+                throw new ArgumentOutOfRangeException("settings", "ErrorStore 'size' must be positive");
 
             switch (settings.Type)
             {
@@ -518,7 +518,8 @@ namespace StackExchange.Exceptional
                 case "SQL":
                     return new SQLErrorStore(settings);
                 default:
-                    throw new Exception("Unknwon error store type: " + settings.Type);
+                    var type = Type.GetType(settings.Type);                    
+                    return (ErrorStore)Activator.CreateInstance(type, settings);
             }
         }
 

--- a/StackExchange.Exceptional/ExtensionMethods.cs
+++ b/StackExchange.Exceptional/ExtensionMethods.cs
@@ -8,7 +8,7 @@ using System.Web.Script.Serialization;
 
 namespace StackExchange.Exceptional.Extensions
 {
-    internal static class ExtensionMethods
+    public static class ExtensionMethods
     {
         /// <summary>
         /// returns a html span element with relative time elapsed since this event occurred, eg, "3 months ago" or "yesterday"; 


### PR DESCRIPTION
Previously, custom error stores could be used only using registration by code, I've added possibility to use configuration for custom error stores.
