### PR TITLE
Adding 'name' property to <Exceptional> config section.

### DIFF
--- a/StackExchange.Exceptional/Settings.cs
+++ b/StackExchange.Exceptional/Settings.cs
@@ -20,7 +20,13 @@ namespace StackExchange.Exceptional
         /// </summary>
         [ConfigurationProperty("applicationName", IsRequired = true)]
         public string ApplicationName { get { return this["applicationName"] as string; } }
-        
+
+        /// <summary>
+        /// An optional name to help enable transformations when application name varies from one environment to the next
+        /// </summary>
+        [ConfigurationProperty("name", IsRequired = false)]
+        public string Name { get { return this["name"] as string; } }
+
         /// <summary>
         /// A collection of list types all with a Name attribute
         /// </summary>


### PR DESCRIPTION
We like to put the environment in our application names. Things like "REST API (dev)" and "REST API (prod)".

The problem is that when we want to do an xdt transformation on our web.configs, we have no elements to transform on since application name will vary per environment.

Adding an optional "name" property to allow xdt transformations.  Shouldn't break existing configs and allows application name to change with environments.
