### PR TITLE
Fixed "Wehther" typos

### DIFF
--- a/StackExchange.Exceptional/ErrorStore.cs
+++ b/StackExchange.Exceptional/ErrorStore.cs
@@ -528,7 +528,7 @@ namespace StackExchange.Exceptional
         /// so that they don't have to carry a reference to System.Web
         /// </summary>
         /// <param name="ex">The exception to log</param>
-        /// <param name="appendFullStackTrace">Wehther to append a full stack trace to the exception's detail</param>
+        /// <param name="appendFullStackTrace">Whether to append a full stack trace to the exception's detail</param>
         /// <param name="rollupPerServer">Whether to log up per-server, e.g. errors are only duplicates if they have same stack on the same machine</param>
         /// <param name="customData">Any custom data to store with the exception like UserId, etc...this will be rendered as JSON in the error view for script use</param>
         public static Error LogExceptionWithoutContext(Exception ex, bool appendFullStackTrace = false, bool rollupPerServer = false, Dictionary<string, string> customData = null)
@@ -541,7 +541,7 @@ namespace StackExchange.Exceptional
         /// </summary>
         /// <param name="ex">The exception to log</param>
         /// <param name="context">The HTTPContext to record variables from.  If this isn't a web request, pass <see langword="null" /> in here</param>
-        /// <param name="appendFullStackTrace">Wehther to append a full stack trace to the exception's detail</param>
+        /// <param name="appendFullStackTrace">Whether to append a full stack trace to the exception's detail</param>
         /// <param name="rollupPerServer">Whether to log up per-server, e.g. errors are only duplicates if they have same stack on the same machine</param>
         /// <param name="customData">Any custom data to store with the exception like UserId, etc...this will be rendered as JSON in the error view for script use</param>
         /// <param name="applicationName">If specified, the application name to log with, if not specified the name in the config is used</param>


### PR DESCRIPTION
Fixed two typos in the parameter documentation for ErrorStore's LogExceptionWithoutContext()
