### PR TITLE
Return null from GetPairs/GetNameValueCollection if value is null

### DIFF
--- a/StackExchange.Exceptional/Error.cs
+++ b/StackExchange.Exceptional/Error.cs
@@ -475,7 +475,7 @@ namespace StackExchange.Exceptional
         private List<NameValuePair> GetPairs(NameValueCollection nvc)
         {
             var result = new List<NameValuePair>();
-            if (nvc == null) return result;
+            if (nvc == null) return null;
 
             for (int i = 0; i < nvc.Count; i++)
             {
@@ -487,7 +487,7 @@ namespace StackExchange.Exceptional
         private NameValueCollection GetNameValueCollection(List<NameValuePair> pairs)
         {
             var result = new NameValueCollection();
-            if (pairs == null) return result;
+            if (pairs == null) return null;
 
             foreach(var p in pairs)
             {


### PR DESCRIPTION
During deserialization of a `List<>` property, Json.net first checks to see if the property is `null`. If _not_, then it avoids calling the property `set` and simply calls `Add()` to the value returned by the `get`.

If the property _is_ null, then it will create the list, and then call the `set` on that property.

This change makes the collection properties of the `Error` class work with Json.net. `JavascriptSerializer` is unaffected and should work as it did previously.
