### PR TITLE
Added option to ignore hosts in Web.config

### DIFF
--- a/Samples.MVC4/Web.config
+++ b/Samples.MVC4/Web.config
@@ -25,6 +25,10 @@
         <!-- Exceptions of the type here will not be logged, if you want to ignore an entire class of exception-->
         <!--<add type="System.Exception" />-->
       </Types>
+      <Hosts>
+        <!-- Exceptions originating from the hosts added below will be ignored. -->
+        <!--<add name="localhost" />-->
+      </Hosts>      
     </IgnoreErrors>
     <LogFilters>
       <Form>

--- a/StackExchange.Exceptional/ErrorStore.cs
+++ b/StackExchange.Exceptional/ErrorStore.cs
@@ -25,6 +25,8 @@ namespace StackExchange.Exceptional
         private static List<Regex> _ignoreRegex;
         [ThreadStatic]
         private static List<string> _ignoreExceptions;
+        [ThreadStatic]
+        private static List<string> _ignoreHosts;
 
         private static ConcurrentQueue<Error> _writeQueue;
 
@@ -187,6 +189,16 @@ namespace StackExchange.Exceptional
         {
             get { return _ignoreExceptions ?? (_ignoreExceptions = Settings.Current.Ignore.Types.All.Select(r => r.Type).ToList()); }
         }
+
+        /// <summary>
+        /// Gets the list of exceptions to ignore specified in the configuration file
+        /// 
+        /// </summary>
+        public static List<string> IgnoreHosts
+        {
+            get { return _ignoreHosts ?? (_ignoreHosts = Settings.Current.Ignore.Hosts.All.Select(r => r.Name).ToList()); }
+        }
+
 
         /// <summary>
         /// Gets the default error store specified in the configuration, 
@@ -579,6 +591,10 @@ namespace StackExchange.Exceptional
                                     RollupPerServer = rollupPerServer,
                                     CustomData = customData
                                 };
+
+                if (IgnoreHosts.Any(host => error.Host.Contains(host)))
+                    return null;
+
 
                 if (GetIPAddress != null)
                 {

--- a/StackExchange.Exceptional/Settings.IgnoreErrors.cs
+++ b/StackExchange.Exceptional/Settings.IgnoreErrors.cs
@@ -36,6 +36,14 @@ namespace StackExchange.Exceptional
             {
                 get { return this["Types"] as SettingsCollection<IgnoreType>; }
             }
+            /// <summary>
+            /// Hosts collection for errors to ignore.  Any Machine Name matching any name here will not be logged
+            /// </summary>
+            [ConfigurationProperty("Hosts")]
+            public SettingsCollection<IgnoreHost> Hosts
+            {
+                get { return this["Hosts"] as SettingsCollection<IgnoreHost>; }
+            }
         }
     }
 
@@ -83,4 +91,17 @@ namespace StackExchange.Exceptional
         [ConfigurationProperty("type", IsRequired = true)]
         public string Type { get { return this["type"] as string; } }
     }
+
+    /// <summary>
+    /// A host entry, to match against hosts to see if we should ignore them
+    /// </summary>
+    public class IgnoreHost : Settings.SettingsCollectionElement
+    {
+        /// <summary>
+        /// The name that describes this ignored type
+        /// </summary>
+        [ConfigurationProperty("name", IsRequired = true)]
+        public override string Name { get { return this["name"] as string; } }
+    }
+
 }


### PR DESCRIPTION
We noticed that you couldn't ignore errors by host (ex: localhost). We're using this code at work and thought it would benefit the community to have it added to the project.