### PR TITLE
MySQL tweaks.

### DIFF
--- a/StackExchange.Exceptional/Dapper/Dapper.cs
+++ b/StackExchange.Exceptional/Dapper/Dapper.cs
@@ -1945,7 +1945,7 @@ Type type, IDataReader reader, int startBound = 0, int length = -1, bool returnN
     /// <summary>
     /// A bag of parameters that can be passed to the Dapper Query and Execute methods
     /// </summary>
-    internal class DynamicParameters : SqlMapper.IDynamicParameters
+    public class DynamicParameters : SqlMapper.IDynamicParameters
     {
         static Dictionary<SqlMapper.Identity, Action<IDbCommand, object>> paramReaderCache = new Dictionary<SqlMapper.Identity, Action<IDbCommand, object>>();
 

--- a/StackExchange.Exceptional/ErrorStore.cs
+++ b/StackExchange.Exceptional/ErrorStore.cs
@@ -543,12 +543,13 @@ namespace StackExchange.Exceptional
         {
             var result = new List<Type>();
             // Get the current directory, based on Where StackExchange.Exceptional.dll is located
-            var path = typeof (ErrorStore).Assembly.Location;
-            var dir = Path.GetDirectoryName(path);
 
-            if (dir == null)
+            Uri assemblyUri = new Uri(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase));
+            var dir= assemblyUri.LocalPath;
+
+            if (String.IsNullOrEmpty(dir))
             {
-                Trace.WriteLine("Error loading Error stores, path: " + path);
+                Trace.WriteLine("Error loading Error stores, abs path: " + assemblyUri.AbsolutePath);
                 return result;
             }
 


### PR DESCRIPTION
Firstly, I changed the method that ErrorStore uses to get the assembly path - as per the comments I made on pull request #49.

So - re: `LogError` in MySQL. I'm a bit stumped. MySQL.NET data connector doesn't support OUT params unless it's a sproc. So you can't fire an update that returns a GUID like you do.

I tried a few different things, and I've tweaked the code a little, here are the options:

* Use `ON DUPLICATE KEY UPDATE` to insert/update in one hit, but that wouldn't work with the minDate criteria, because it has to be based unique index on the table (so we'd have to include the rollup date as a column to make that work)

* Create a sproc. Would work, but feels wrong

* Wrap anything we're still concerned about in a transaction if that will help, which I'm not sure about.