### PR TITLE
Prevent Emailing Duplicate Errors

### DIFF
--- a/StackExchange.Exceptional.MySQL/MySQLErrorStore.cs
+++ b/StackExchange.Exceptional.MySQL/MySQLErrorStore.cs
@@ -204,6 +204,7 @@ Update Exceptions
                                 And ApplicationName = @ApplicationName
                                 And DeletionDate Is Null
                                 And CreationDate >= @minDate limit 1 ", queryParams).First();
+                        error.IsOriginalError = false;
                         return;
                     }
                 }
@@ -234,9 +235,7 @@ Values (@GUID, @ApplicationName, @MachineName, @CreationDate, @Type, @IsProtecte
                                 error.ErrorHash,
                                 error.DuplicateCount
                             });
-
-                
-                
+                error.IsOriginalError = true;
             }
         }
 

--- a/StackExchange.Exceptional/Email/ErrorEmailer.cs
+++ b/StackExchange.Exceptional/Email/ErrorEmailer.cs
@@ -20,7 +20,8 @@ namespace StackExchange.Exceptional.Email
         private static int? Port { get; set; }
 
         private static NetworkCredential Credentials { get; set; }
-        private static bool EnableSSL { get; set; } 
+        private static bool EnableSSL { get; set; }
+        private static bool PreventDuplicates { get; set; }
 
         /// <summary>
         /// Whether email functionality is enabled
@@ -61,6 +62,7 @@ namespace StackExchange.Exceptional.Email
             if (eSettings.SMTPPort != 25) Port = eSettings.SMTPPort;
             EnableSSL = eSettings.SMTPEnableSSL;
 
+            PreventDuplicates = eSettings.PreventDuplicates;
             Enabled = true;
             
         }
@@ -72,6 +74,8 @@ namespace StackExchange.Exceptional.Email
         public static void SendMail(Error error)
         {
             if (!Enabled) return;
+            // The following prevents errors that have already been stored from being emailed a second time.
+            if (PreventDuplicates && !error.IsOriginalError) return;
             try
             {
 

--- a/StackExchange.Exceptional/Error.cs
+++ b/StackExchange.Exceptional/Error.cs
@@ -97,6 +97,7 @@ namespace StackExchange.Exceptional
             Detail = e.ToString();
             CreationDate = DateTime.UtcNow;
             DuplicateCount = 1;
+            IsOriginalError = true; //Default to true, but it should always be set by the store.
             
             var httpException = e as HttpException;
             if (httpException != null)
@@ -221,7 +222,7 @@ namespace StackExchange.Exceptional
         }
 
         /// <summary>
-        /// Gets a unique-enough hash of this error.  Stored as a quick comparison mehanism to rollup duplicate errors.
+        /// Gets a unique-enough hash of this error.  Stored as a quick comparison mechanism to rollup duplicate errors.
         /// </summary>
         /// <returns>"Unique" hash for this error</returns>
         public int? GetHash()
@@ -331,6 +332,13 @@ namespace StackExchange.Exceptional
         /// "IgnoreSimilarExceptionsThreshold" TimeSpan value.
         /// </summary>
         public int? DuplicateCount { get; set; }
+
+        /// <summary>
+        /// This flag is to indicate that there were no matches of this error in the store nor in the queue. This is slightly different than checking for DuplicateCount > 1
+        /// because DuplicateCount can be incremented even before the error is committed to the store.
+        /// </summary>
+        [ScriptIgnore]
+        public bool IsOriginalError { get; set; }
 
         /// <summary>
         /// Gets the SQL command text assocaited with this error

--- a/StackExchange.Exceptional/ErrorStore.cs
+++ b/StackExchange.Exceptional/ErrorStore.cs
@@ -611,7 +611,7 @@ namespace StackExchange.Exceptional
                 var error = new Error(ex, context, applicationName)
                                 {
                                     RollupPerServer = rollupPerServer,
-                                    CustomData = customData
+                                    CustomData = customData ?? new Dictionary<string, string>()
                                 };
 
                 if (GetIPAddress != null)
@@ -637,7 +637,7 @@ namespace StackExchange.Exceptional
                 if (appendFullStackTrace)
                 {
                     var frames = new StackTrace(fNeedFileInfo: true).GetFrames();
-                    if (frames != null)
+                    if (frames != null && frames.Length > 2)
                         error.Detail += "\n\nFull Trace:\n\n" + string.Join("", frames.Skip(2));
                     error.ErrorHash = error.GetHash();
                 }

--- a/StackExchange.Exceptional/Settings.Email.cs
+++ b/StackExchange.Exceptional/Settings.Email.cs
@@ -42,6 +42,9 @@ namespace StackExchange.Exceptional
 
         /// <include file='SharedDocs.xml' path='SharedDocs/IEmailSettings/Member[@name="SMTPEnableSSL"]/*' />
         bool SMTPEnableSSL { get; }
+
+        /// <include file='SharedDocs.xml' path='SharedDocs/IEmailSettings/Member[@name="PreventDuplicates"]/*' />
+        bool PreventDuplicates { get; }
     }
     
     /// <summary>
@@ -65,6 +68,8 @@ namespace StackExchange.Exceptional
         public string SMTPPassword { get; set; }
         /// <include file='SharedDocs.xml' path='SharedDocs/IEmailSettings/Member[@name="SMTPEnableSSL"]/*' />
         public bool SMTPEnableSSL { get; set; }
+        /// <include file='SharedDocs.xml' path='SharedDocs/IEmailSettings/Member[@name="PreventDuplicates"]/*' />
+        public bool PreventDuplicates { get; set; }
 
         /// <summary>
         /// Creates an email settings object defaulting the SMTP port to 25
@@ -111,5 +116,12 @@ namespace StackExchange.Exceptional
         /// <include file='SharedDocs.xml' path='SharedDocs/IEmailSettings/Member[@name="SMTPEnableSSL"]/*' />
         [ConfigurationProperty("smtpEnableSsl"), DefaultValue(typeof(bool), "false")]
         public bool SMTPEnableSSL => (bool)this["smtpEnableSsl"];
+
+        /// <include file='SharedDocs.xml' path='SharedDocs/IEmailSettings/Member[@name="PreventDuplicates"]/*' />
+        [ConfigurationProperty("preventDuplicates"), DefaultValue(typeof(bool), "false")]
+        public bool PreventDuplicates
+        {
+            get { return (bool)this["preventDuplicates"]; }
+        }
     }
 }

--- a/StackExchange.Exceptional/SharedDocs.xml
+++ b/StackExchange.Exceptional/SharedDocs.xml
@@ -40,5 +40,10 @@
                 Whether to use SSL when sending via SMTP
             </summary>
         </Member>
+        <Member name="PreventDuplicates">
+            <summary>
+                Flags whether or not emails are sent for duplicate errors.
+            </summary>
+        </Member>
     </IEmailSettings>
 </SharedDocs>

--- a/StackExchange.Exceptional/Stores/JSONErrorStore.cs
+++ b/StackExchange.Exceptional/Stores/JSONErrorStore.cs
@@ -142,6 +142,7 @@ namespace StackExchange.Exceptional.Stores
                 // just update the existing file after incrementing its "duplicate count"
                 original.DuplicateCount = original.DuplicateCount.GetValueOrDefault(0) + error.DuplicateCount;
                 error.GUID = original.GUID;
+                error.IsOriginalError = false;
 
                 FileInfo f;
                 if (!TryGetErrorFile(original.GUID, out f))
@@ -166,6 +167,7 @@ namespace StackExchange.Exceptional.Stores
 
                 // we added a new file, so clean up old smack over our max errors limit
                 RemoveOldErrors();
+                error.IsOriginalError = true;
             }
         }
 

--- a/StackExchange.Exceptional/Stores/MemoryErrorStore.cs
+++ b/StackExchange.Exceptional/Stores/MemoryErrorStore.cs
@@ -121,6 +121,7 @@ namespace StackExchange.Exceptional.Stores
                     {
                         dupe.DuplicateCount += error.DuplicateCount;
                         error.GUID = dupe.GUID;
+                        error.IsOriginalError = false;
                         return;
                     }
                 }
@@ -131,6 +132,7 @@ namespace StackExchange.Exceptional.Stores
                 }
 
                 _errors.Add(error);
+                error.IsOriginalError = true;
             }
         }
 

--- a/StackExchange.Exceptional/Stores/SQLErrorStore.cs
+++ b/StackExchange.Exceptional/Stores/SQLErrorStore.cs
@@ -193,6 +193,7 @@ Update Exceptions
                     if (count > 0)
                     {
                         error.GUID = queryParams.Get<Guid>("@newGUID");
+                        error.IsOriginalError = false;
                         return;
                     }
                 }
@@ -222,6 +223,7 @@ Values (@GUID, @ApplicationName, @MachineName, @CreationDate, @Type, @IsProtecte
                             error.ErrorHash,
                             error.DuplicateCount
                         });
+                error.IsOriginalError = true;
             }
         }
 


### PR DESCRIPTION
@NickCraver This fixes #61 without the downsides that you enumerated. I found out that my code didn't really have to change much to match the changes that you had made. I tried to keep the changes as clean as possible. Let me know if there's anything that you would like me to change. :wink:

Added a new PreventDuplicates configuration option to the ErrorEmailer
with the related code changes necessary to prevent the ErrorEmailer from
mailing notifications when the error was detected to be a duplicate by
the ErrorStore as configured by the RollupThreshold value. One of those
changes was the addition of a simple bool flag on Error called
IsOriginalError, which should only be true when the error was not
determined to be a duplicate of a previously stored value, or if it was
queued and the queue didn't already contain a matching error.

Also contains a few minor bug fixes.