### PR TITLE
Correct NullReferenceException on ServerVariables collection

### DIFF
--- a/StackExchange.Exceptional/Error.cs
+++ b/StackExchange.Exceptional/Error.cs
@@ -120,22 +120,34 @@ namespace StackExchange.Exceptional
             var request = context.Request;
 
             Func<Func<HttpRequest, NameValueCollection>, NameValueCollection> tryGetCollection = getter =>
+            {
+                try
                 {
-                    try
+                    var original = getter(request);
+                    var copy = new NameValueCollection();
+                    foreach (var key in original.AllKeys)
                     {
-                        return new NameValueCollection(getter(request));
+                        try
+                        {
+                            foreach (var value in original.GetValues(key))
+                            {
+                                copy.Add(key, value);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Trace.WriteLine(string.Format("Error getting collection value [{0}]: {1}", key, e.Message));
+                            copy.Add(key, "[Error getting value: " + e.Message + "]");
+                        }
                     }
-                    catch (HttpRequestValidationException e)
-                    {
-                        Trace.WriteLine("Error parsing collection: " + e.Message);
-                        return new NameValueCollection {{CollectionErrorKey, e.Message}};
-                    }
-                    catch (NullReferenceException e)
-                    {
-                        Trace.WriteLine("Error parsing collection: " + e.Message);
-                        return new NameValueCollection {{CollectionErrorKey, e.Message}};
-                    }
-                };
+                    return copy;
+                }
+                catch (Exception e)
+                {
+                    Trace.WriteLine("Error parsing collection: " + e.Message);
+                    return new NameValueCollection { { CollectionErrorKey, e.Message } };
+                }
+            };
 
             ServerVariables = tryGetCollection(r => r.ServerVariables);
             QueryString = tryGetCollection(r => r.QueryString);

--- a/StackExchange.Exceptional/Error.cs
+++ b/StackExchange.Exceptional/Error.cs
@@ -133,7 +133,7 @@ namespace StackExchange.Exceptional
                     catch (NullReferenceException e)
                     {
                         Trace.WriteLine("Error parsing collection: " + e.Message);
-                        return new NameValueCollection { { "CollectionFetchError", e.Message } };
+                        return new NameValueCollection {{CollectionErrorKey, e.Message}};
                     }
                 };
 

--- a/StackExchange.Exceptional/Error.cs
+++ b/StackExchange.Exceptional/Error.cs
@@ -130,6 +130,11 @@ namespace StackExchange.Exceptional
                         Trace.WriteLine("Error parsing collection: " + e.Message);
                         return new NameValueCollection {{CollectionErrorKey, e.Message}};
                     }
+                    catch (NullReferenceException e)
+                    {
+                        Trace.WriteLine("Error parsing collection: " + e.Message);
+                        return new NameValueCollection { { "CollectionFetchError", e.Message } };
+                    }
                 };
 
             ServerVariables = tryGetCollection(r => r.ServerVariables);


### PR DESCRIPTION
Related to this post: http://stackoverflow.com/q/38854251/4023606

When `authenticationManager.User = new ClaimsPrincipal();` is executed,
the following 3 values (AUTH_TYPE, AUTH_USER, REMOTE_USER) are set to
null inside the System.Web.HttpContext.Current.Request.ServerVariables
object, even though the keys are still there inside the collection.
This causes any exception thrown by the application after that line to not get logged
because Exceptional doesn't handle the NullReferenceException.
