### PR TITLE
patching up the assembly directory lookup for the nuget era

### DIFF
--- a/src/StackExchange.Exceptional/ErrorStore.cs
+++ b/src/StackExchange.Exceptional/ErrorStore.cs
@@ -530,8 +530,8 @@ namespace StackExchange.Exceptional
             var result = new List<Type>();
             // Get the current directory, based on Where StackExchange.Exceptional.dll is located
 
-            Uri assemblyUri = new Uri(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase));
-            var dir= assemblyUri.LocalPath;
+            var assemblyUri = new Uri(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase);
+            var dir = System.IO.Path.GetDirectoryName(assemblyUri.LocalPath);
 
             if (String.IsNullOrEmpty(dir))
             {


### PR DESCRIPTION
Fixes following exception:

```
The path is not of a legal form.
at System.IO.Path.NewNormalizePathLimitedChecks(String path, Int32 maxPathLength, Boolean expandShortPaths)
at System.IO.Path.NormalizePath(String path, Boolean fullCheck, Int32 maxPathLength, Boolean expandShortPaths)
at System.IO.Path.InternalGetDirectoryName(String path)
at StackExchange.Exceptional.ErrorStore.GetErrorStores() in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\ErrorStore.cs:line 533
at StackExchange.Exceptional.ErrorStore.GetFromSettings(ErrorStoreSettings settings) in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\ErrorStore.cs:line 504 at StackExchange.Exceptional.ErrorStore.GetErrorStoreFromConfig() in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\ErrorStore.cs:line 491 at StackExchange.Exceptional.ErrorStore.get_Default() in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\ErrorStore.cs:line 190 at StackExchange.Exceptional.Pages.ErrorList.Execute() in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\Pages\ErrorList.generated.cs:line 0 at StackExchange.Exceptional.RazorPageBase.TransformText() in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\RazorPage.cs:line 57 at StackExchange.Exceptional.RazorPageBase.ProcessRequest() in C:\TeamCity\buildAgent\work\d20fce4a5bb47bd3\StackExchange.Exceptional\RazorPage.cs:line 70

```