### PR TITLE
Fixed broken link in SqlSetup.md

### DIFF
--- a/docs/SqlSetup.md
+++ b/docs/SqlSetup.md
@@ -6,7 +6,7 @@ title: 'SQL Setup'
 Install for SQL is fairly straightforward, you'll need to do the following:
 
 1. Give the application permissions to a database
-2. Run the [SQL to create the Exceptions table](https://github.com/NickCraver/StackExchange.Exceptional/blob/master/DbScripts/SqlServerExceptions.sql)
+2. Run the [SQL to create the Exceptions table](https://github.com/NickCraver/StackExchange.Exceptional/blob/master/DBScripts/SqlServer.sql)
 3. Configure the application to use this error store, either [in the web.config](https://github.com/NickCraver/StackExchange.Exceptional/wiki/Setup) or in code.
 
 ### web.config example:


### PR DESCRIPTION
Markdown link to "SQL to create the Exceptions table" was broken. Changed from `SqlServerExceptions.sql` to `SqlServer.sql`