### PR TITLE
Fixes null reference exceptions

### DIFF
--- a/src/StackExchange.Exceptional.AspNetCore/Extensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/Extensions.cs
@@ -179,17 +179,16 @@ namespace StackExchange.Exceptional
             if (request.HasFormContentType)
             {
                 error.Form = TryGetCollection(r => r.Form);
-            }
-
-            // Filter form variables for sensitive information
-            var formFilters = Settings.Current.LogFilters.Form;
-            if (formFilters?.Count > 0)
-            {
-                foreach (var kv in formFilters)
+                // Filter form variables for sensitive information
+                var formFilters = Settings.Current.LogFilters.Form;
+                if (formFilters?.Count > 0)
                 {
-                    if (kv.Value != null)
+                    foreach (var kv in formFilters)
                     {
-                        error.Form[kv.Key] = kv.Value;
+                        if (kv.Value != null)
+                        {
+                            error.Form[kv.Key] = kv.Value;
+                        }
                     }
                 }
             }

--- a/src/StackExchange.Exceptional.Shared/Settings.cs
+++ b/src/StackExchange.Exceptional.Shared/Settings.cs
@@ -133,13 +133,13 @@ namespace StackExchange.Exceptional
             /// Regular expressions collection for errors to ignore.  
             /// Any errors with a .ToString() matching any <see cref="Regex"/> here will not be logged.
             /// </summary>
-            public List<Regex> Regexes { get; set; }
+            public List<Regex> Regexes { get; set; } = new List<Regex>();
 
             /// <summary>
             /// Types collection for errors to ignore.  
             /// Any errors with a Type matching any name here will not be logged.
             /// </summary>
-            public HashSet<string> Types { get; set; }
+            public HashSet<string> Types { get; set; } = new HashSet<string>();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes two issues that occur if you add different settings:

1. When trying to replace values in the Form Collection of an Error, a NullReferenceException occures if the request has no FormContentType. Since it makes no sense to override values that do not exist and especially since we shouldn´t use Form at all if the Request has no FormContentType we only should replace this values for requests with FormContentType

2. While I was testing the new JSON settings implementation I found an issue that occurred when adding IgnoreSettings (Regex or Types). When creating the Settings object and in further consequence the IgnoreSettings object, the two Lists that are properties of this class are not instantiated. This lead to a NullReferenceException when trying to fill this Lists on Deserialization.


Both errors are occuring in StackExchange.Exceptional and in StackExchange.Exceptional.AspNetCore because they are located in StackExchange.Exceptional.Shared.