### PR TITLE
Fixing the way the Form Filters are working and an omission in MySQLErrorStore

### DIFF
--- a/src/StackExchange.Exceptional.AspNetCore/Extensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/Extensions.cs
@@ -187,9 +187,9 @@ namespace StackExchange.Exceptional
             {
                 foreach (var kv in formFilters)
                 {
-                    if (kv.Value != null)
+                    if (error.Form[kv.Key] != null)
                     {
-                        error.Form[kv.Key] = kv.Value;
+                        error.Form[kv.Key] = kv.Value ?? "";
                     }
                 }
             }

--- a/src/StackExchange.Exceptional.MySQL/MySQLErrorStore.cs
+++ b/src/StackExchange.Exceptional.MySQL/MySQLErrorStore.cs
@@ -298,6 +298,8 @@ Select *
             Error result = Error.FromJson(sqlError.FullJson);
             result.DuplicateCount = sqlError.DuplicateCount;
             result.DeletionDate = sqlError.DeletionDate;
+            result.IsProtected = sqlError.IsProtected;
+            result.LastLogDate = sqlError.LastLogDate;
             return result;
         }
 

--- a/src/StackExchange.Exceptional/Extensions.cs
+++ b/src/StackExchange.Exceptional/Extensions.cs
@@ -179,9 +179,9 @@ namespace StackExchange.Exceptional
             {
                 foreach (var kv in formFilters)
                 {
-                    if (kv.Value != null)
+                    if (error.Form[kv.Key] != null)
                     {
-                        error.Form[kv.Key] = kv.Value;
+                        error.Form[kv.Key] = kv.Value ?? "";
                     }
                 }
             }


### PR DESCRIPTION
This fixes two issues. The less significant issue is that the `MySQLErrorStore.GetErrorAsync` wasn't setting `Error.IsProtected` and `Error.LastLogDate`. This brings it into parity with `SQLErrorStore.GetErrorAsync`.

The bigger issue is with a change in how the Form Filters are processed in V2. I first noticed this when reviewing the changes in #94, but the issue was already there in the existing code and also in the corresponding Classic ASP.NET code. The key difference here is that in V1, it is checking to see if the `Error.Form` collection has a value for the key that is being filtered out. But in V2, it is only checking to see that the filter has a value to assign. 

This means that if I had a form on my site that asked the user for their SSN (for example), I would want to prevent that field from being included in any error logs by adding a Form Filter for the "SSN" field. In V1 this works just fine and if that particular form's postback has an error, my log would include something like `"SSN": "[SSN Removed]"`, but any errors that happen anywhere else would not have it at all. In V2, every error would have `"SSN": "[SSN Removed]"` included, regardless of whether there was an SSN in the form or not.

I'm sure this will conflict with the changes made in #94, but I'm hoping it'll be easy to resolve. (My git skills are still pretty weak, so if there's some way I could have factored that in to avoid the conflict, sorry!)