### PR TITLE
Fixed sample appsettings.json in AspDotNetCore.md

### DIFF
--- a/docs/AspDotNetCore.md
+++ b/docs/AspDotNetCore.md
@@ -34,12 +34,11 @@ and configure Exceptional in your `Configuration`, e.g. in your `appsettings.jso
 ```json
 {
   "Exceptional": {
-    "ApplicationName": "Samples (ASP.NET Core)"
-  },
-  "ErrorStore": {
-    "Type": "SQL",
-    "ConnectionString": "Server=.;Database=Local.Exceptions;Trusted_Connection=True;"
-  }
+    "ApplicationName": "Samples (ASP.NET Core)",
+    "ErrorStore": {
+      "Type": "SQL",
+      "ConnectionString": "Server=.;Database=Local.Exceptions;Trusted_Connection=True;"
+    }
 }
 ```
 ...or you can use a combination of the two:


### PR DESCRIPTION
Looking at the [full schema](https://github.com/NickCraver/StackExchange.Exceptional/blob/master/samples/Samples.AspNetCore/appsettings.json), the `ErrorStore` settings should be on the same hierarchical level as `ApplicationName`.

In the sample config, it is one level up (inline with `Exceptional`).