### PR TITLE
Fix for issue 101: IPAddress not set in ASPNetcore

### DIFF
--- a/src/StackExchange.Exceptional.AspNetCore/Extensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/Extensions.cs
@@ -174,6 +174,7 @@ namespace StackExchange.Exceptional
                 { "Request Method", request.Method },
                 { "Scheme", request.Scheme },
                 { "Url", error.Url },
+                { "REMOTE_ADDR", context.Connection.RemoteIpAddress.ToString() }
             };
             error.QueryString = TryGetCollection(r => r.Query);
             if (request.HasFormContentType)

--- a/src/StackExchange.Exceptional.Shared/Error.cs
+++ b/src/StackExchange.Exceptional.Shared/Error.cs
@@ -205,6 +205,10 @@ namespace StackExchange.Exceptional
                     CustomData.Add(Constants.CustomDataErrorKey, "Fetching IP Address: " + gipe);
                 }
             }
+            else
+            {
+                IPAddress = ServerVariables?.GetRemoteIP();
+            }
         }
 
         /// <summary>
@@ -449,15 +453,10 @@ namespace StackExchange.Exceptional
             set => _httpMethod = value;
         }
 
-        private string _ipAddress;
         /// <summary>
         /// The IPAddress of the request causing this error.
         /// </summary>
-        public string IPAddress
-        {
-            get => _ipAddress ?? (_ipAddress = ServerVariables?.GetRemoteIP() ?? "");
-            set => _ipAddress = value;
-        }
+        public string IPAddress { get; set; }
 
         /// <summary>
         /// JSON populated from database stored, deserialized after if needed.


### PR DESCRIPTION
As described in #101 in AspNetCore there is an issue with setting the remote ip for the error. This should fix this issue. Only thing that needs to be checked is, if we want to save IP Addresses as IPv4, or IPv6.

Did not set IPAddress to a valid value since the REMOTE_ADDR value wasn´t added to the ServerVariables in AspNetCore

Moved fallback initialization for IPAddress (Servervariables) to SetIPAddress method.