### PR TITLE
Add check for HasFormContentType to fix DeleteAll

### DIFF
--- a/src/StackExchange.Exceptional.AspNetCore/ExceptionalMiddleware.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/ExceptionalMiddleware.cs
@@ -153,7 +153,7 @@ namespace StackExchange.Exceptional
             switch (context.Request.Method)
             {
                 case "POST":
-                    errorGuid = context.Request.Form["guid"].ToString() ?? string.Empty;
+                    errorGuid = context.Request.HasFormContentType ? context.Request.Form["guid"].ToString() : string.Empty;
                     switch (resource)
                     {
                         case KnownRoutes.Delete:


### PR DESCRIPTION
DeleteAll would fail due to missing form content type.  Checking HttpRequest.HasFormContentType before attempting to pull the guid from the form fixed the failure.