### PR TITLE
Fix  error file path on mac/linux

### DIFF
--- a/src/StackExchange.Exceptional.Shared/Stores/JSONErrorStore.cs
+++ b/src/StackExchange.Exceptional.Shared/Stores/JSONErrorStore.cs
@@ -162,7 +162,7 @@ namespace StackExchange.Exceptional.Stores
             else
             {
                 string timeStamp = DateTime.UtcNow.ToString("u").Replace(":", "").Replace(" ", "");
-                string fileName = $@"{_path}\error-{timeStamp}-{detailHash}-{error.GUID.ToString("N")}.json";
+                string fileName = $@"{_path}/error-{timeStamp}-{detailHash}-{error.GUID.ToString("N")}.json";
 
                 var file = new FileInfo(fileName);
                 using (var outstream = file.CreateText())


### PR DESCRIPTION
For file path, the '/' can be used in mac/linux/windows. But the '\' is only valid for windows.