### PR TITLE
Fix issue where AppName is overwritten by default

### DIFF
--- a/src/StackExchange.Exceptional.Shared/Error.cs
+++ b/src/StackExchange.Exceptional.Shared/Error.cs
@@ -67,7 +67,7 @@ namespace StackExchange.Exceptional
                 baseException = e.GetBaseException();
 
             GUID = Guid.NewGuid();
-            ApplicationName = applicationName ?? settings.Store?.ApplicationName;
+            ApplicationName = applicationName ?? settings.DefaultStore.ApplicationName ?? settings.Store?.ApplicationName;
             Category = category;
             MachineName = Environment.MachineName;
             Type = baseException.GetType().FullName;

--- a/src/StackExchange.Exceptional.Shared/ErrorStoreSettings.cs
+++ b/src/StackExchange.Exceptional.Shared/ErrorStoreSettings.cs
@@ -10,7 +10,7 @@ namespace StackExchange.Exceptional
         /// <summary>
         /// Application name to log with.
         /// </summary>
-        public string ApplicationName { get; set; } = "My Application";
+        public string ApplicationName { get; set; }
 
         private string _type;
         /// <summary>


### PR DESCRIPTION
I've encountered an issue where my in-code configured `ApplicationName` is overwritten.  I configure exceptional like so in a class library:

```csharp
Exceptional.Configure(settings =>
{
    settings.DefaultStore = new SQLErrorStore(new ErrorStoreSettings()
    {
        ApplicationName = applicationName,
        ConnectionString = connectionString
    });
});
```

In this case, a new `Error`, when initialized, was not taking the `DefaultStore`'s `ApplicationName` property.  This fixes my issue by checking `DefaultStore` first before falling back.

**Edit:** I should mention it was defaulting to `"My Application"`.