### PR TITLE
Update AspDotNetCore.md

### DIFF
--- a/docs/AspDotNetCore.md
+++ b/docs/AspDotNetCore.md
@@ -36,7 +36,7 @@ and configure Exceptional in your `Configuration`, e.g. in your `appsettings.jso
 ```json
 {
   "Exceptional": {
-    "ErrorStore": {
+    "Store": {
       "ApplicationName": "Samples (ASP.NET Core)",
       "Type": "SQL",
       "ConnectionString": "Server=.;Database=Local.Exceptions;Trusted_Connection=True;"


### PR DESCRIPTION
Documentation currently states:
{
  "Exceptional": {
    "ErrorStore": {
      "ApplicationName": "Samples (ASP.NET Core)",
      "Type": "SQL",
      "ConnectionString": "Server=.;Database=Local.Exceptions;Trusted_Connection=True;"
    }
}
The above always loads the MemoryStore.  

The following works properly and is confirmed as functional by the AspNetCore test project:
{
  "Exceptional": {
    "Store": {
      "ApplicationName": "Samples (ASP.NET Core)",
      "Type": "SQL",
      "ConnectionString": "Server=.;Database=Local.Exceptions;Trusted_Connection=True;"
    }
}