### PR TITLE
Throw ArgumentNullException when context is null

### DIFF
--- a/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
@@ -38,6 +38,8 @@ namespace StackExchange.Exceptional
             Dictionary<string, string> customData = null,
             string applicationName = null)
         {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             if (Statics.IsLoggingEnabled)
             {
                 try
@@ -89,6 +91,8 @@ namespace StackExchange.Exceptional
             Dictionary<string, string> customData = null,
             string applicationName = null)
         {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             if (Statics.IsLoggingEnabled)
             {
                 try
@@ -126,7 +130,7 @@ namespace StackExchange.Exceptional
         /// <returns>The passed-in <see cref="Error"/> for chaining.</returns>
         private static void SetProperties(this Error error, HttpContext context)
         {
-            if (error == null || context == null)
+            if (error == null)
             {
                 return;
             }


### PR DESCRIPTION
It took me a while to figure out why context-less logging wasn't working with the ASP.NET Core extension methods. The `ArgumentNullException` points users at the error, instead of having the code enter `catch { ... }` block.