### PR TITLE
Check if url is absolute before trying to use `AbsolutePath`. Fixes #145

### DIFF
--- a/src/StackExchange.Exceptional/ExceptionalAsyncHandler.cs
+++ b/src/StackExchange.Exceptional/ExceptionalAsyncHandler.cs
@@ -118,7 +118,9 @@ namespace StackExchange.Exceptional
                         default:
                             context.Response.Cache.SetCacheability(HttpCacheability.NoCache);
                             context.Response.Cache.SetNoStore();
-                            string actualUrl = Uri.TryCreate(Url, UriKind.RelativeOrAbsolute, out var urlResult) ? urlResult.AbsolutePath : Url;
+
+                            bool isUri = Uri.TryCreate(Url, UriKind.RelativeOrAbsolute, out var urlResult);
+                            string actualUrl = (isUri && urlResult.IsAbsoluteUri) ? urlResult.AbsolutePath : Url;
                             Page(new ErrorListPage(store, settings, actualUrl, await store.GetAllAsync().ConfigureAwait(false)));
                             return;
                     }


### PR DESCRIPTION
Fix up ExceptionalAsyncHandler.cs so requests to /exceptions.axd work