### PR TITLE
Capture data on System.Web.HttpException exceptions. Fixes #147

### DIFF
--- a/src/StackExchange.Exceptional/AspNetExtensions.cs
+++ b/src/StackExchange.Exceptional/AspNetExtensions.cs
@@ -142,7 +142,7 @@ namespace StackExchange.Exceptional
             {
                 error.StatusCode = httpException.GetHttpCode();
             }
-            if (context == null || context.Handler == null)
+            if (context == null)
             {
                 return error;
             }

--- a/src/StackExchange.Exceptional/ExceptionalAsyncHandler.cs
+++ b/src/StackExchange.Exceptional/ExceptionalAsyncHandler.cs
@@ -118,7 +118,9 @@ namespace StackExchange.Exceptional
                         default:
                             context.Response.Cache.SetCacheability(HttpCacheability.NoCache);
                             context.Response.Cache.SetNoStore();
-                            string actualUrl = Uri.TryCreate(Url, UriKind.RelativeOrAbsolute, out var urlResult) ? urlResult.AbsolutePath : Url;
+
+                            bool isUri = Uri.TryCreate(Url, UriKind.RelativeOrAbsolute, out var urlResult);
+                            string actualUrl = (isUri && urlResult.IsAbsoluteUri) ? urlResult.AbsolutePath : Url;
                             Page(new ErrorListPage(store, settings, actualUrl, await store.GetAllAsync().ConfigureAwait(false)));
                             return;
                     }


### PR DESCRIPTION
`System.Web.HttpException` exceptions weren't being captured with all available data (such as Url)