### PR TITLE
Remove async state machine overhead for LogAsync if exception is ignored

### DIFF
--- a/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
@@ -82,7 +82,7 @@ namespace StackExchange.Exceptional
         /// When dealing with a non web requests, pass <see langword="null" /> in for context.  
         /// It shouldn't be forgotten for most web application usages, so it's not an optional parameter.
         /// </remarks>
-        public static async Task<Error> LogAsync(
+        public static Task<Error> LogAsync(
             this Exception ex,
             HttpContext context,
             string category = null,
@@ -105,10 +105,7 @@ namespace StackExchange.Exceptional
                         // Get everything from the HttpContext
                         error.SetProperties(context);
 
-                        if (await error.LogToStoreAsync().ConfigureAwait(false))
-                        {
-                            return error;
-                        }
+                        return LogAsyncCore(error);
                     }
                 }
                 catch (Exception e)
@@ -116,6 +113,15 @@ namespace StackExchange.Exceptional
                     settings?.OnLogFailure?.Invoke(e);
                     Trace.WriteLine(e);
                 }
+            }
+            return Task.FromResult<Error>(null);
+        }
+
+        public static async Task<Error> LogAsyncCore(Error error)
+        {
+            if (await error.LogToStoreAsync().ConfigureAwait(false))
+            {
+                return error;
             }
             return null;
         }

--- a/src/StackExchange.Exceptional/AspNetExtensions.cs
+++ b/src/StackExchange.Exceptional/AspNetExtensions.cs
@@ -105,7 +105,6 @@ namespace StackExchange.Exceptional
 
         private static async Task<Error> LogAsyncCore(Error error)
         {
-
             if (await error.LogToStoreAsync().ConfigureAwait(false))
             {
                 return error;


### PR DESCRIPTION
Based on my tests, gives 20% improvement in "ignore" path