### PR TITLE
QueryString: add parsing filters

### DIFF
--- a/samples/Samples.AspNetCore/appsettings.json
+++ b/samples/Samples.AspNetCore/appsettings.json
@@ -42,6 +42,9 @@
       },
       "Header": {
         "Accept-Language": "*********"
+      },
+      "QueryString": {
+        "queryToken": "*********"
       }
     },
     // Error messages to ignore depending on type or regex pattern

--- a/samples/Samples.MVC5/Web.config
+++ b/samples/Samples.MVC5/Web.config
@@ -33,6 +33,9 @@
       <Headers>
         <add name="X-Auth-Header" replaceWith="**not recorded**" />
       </Headers>
+      <QueryString>
+        <add name="queryToken" replaceWith="**we don't record query tokens!**" />
+      </QueryString>
     </LogFilters>
     <!-- Email settings to send to, if an email per exception is desired, only toAddress is required, other defaults are pulled from the <system.net> section -->
     <Email fromAddress="exceptions@example.com" fromDisplayName="Bob the Builder" toAddress="tester@example.com" smtpHost="localhost" />

--- a/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
@@ -4,11 +4,9 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using StackExchange.Exceptional.Internal;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace StackExchange.Exceptional
@@ -128,8 +126,6 @@ namespace StackExchange.Exceptional
             return null;
         }
 
-        private static readonly ConcurrentDictionary<string, Regex> _regexCache = new ConcurrentDictionary<string, Regex>();
-
         /// <summary>
         /// Sets Error properties pulled from HttpContext, if present.
         /// </summary>
@@ -201,8 +197,7 @@ namespace StackExchange.Exceptional
             {
                 foreach (var kv in queryFilters)
                 {
-                    var regex = _regexCache.GetOrAdd(kv.Key, key => new Regex("(?<=[?&]" + Regex.Escape(key) + "=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled));
-                    queryString = regex.Replace(queryString, kv.Value);
+                    queryString = queryString.QueryStringReplace(kv.Key, kv.Value);
                     if (error.QueryString[kv.Key] != null)
                     {
                         error.QueryString[kv.Key] = kv.Value ?? "";

--- a/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/AspNetCoreExtensions.cs
@@ -207,7 +207,21 @@ namespace StackExchange.Exceptional
                 ["Scheme"] = request.Scheme,
                 ["Url"] = error.FullUrl,
             };
+
             error.QueryString = TryGetCollection(r => r.Query);
+            // Filter query variables for sensitive information
+            var queryFilters = error.Settings.LogFilters.QueryString;
+            if (queryFilters?.Count > 0)
+            {
+                foreach (var kv in queryFilters)
+                {
+                    if (error.QueryString[kv.Key] != null)
+                    {
+                        error.QueryString[kv.Key] = kv.Value ?? "";
+                    }
+                }
+            }
+
             if (request.HasFormContentType)
             {
                 error.Form = TryGetCollection(r => r.Form);

--- a/src/StackExchange.Exceptional.Shared/Internal/ExceptionalSettingsBase.cs
+++ b/src/StackExchange.Exceptional.Shared/Internal/ExceptionalSettingsBase.cs
@@ -194,6 +194,13 @@ namespace StackExchange.Exceptional.Internal
             /// </summary>
             [JsonConverter(typeof(CaseInsensitiveDictionaryConverter<string>))]
             public Dictionary<string, string> Header { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            /// <summary>
+            /// Query string values to replace on save - this prevents logging authentication tokens, etc.
+            /// The key is the query string parameter name to match, the value is what to use when logging.
+            /// </summary>
+            [JsonConverter(typeof(CaseInsensitiveDictionaryConverter<string>))]
+            public Dictionary<string, string> QueryString { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/StackExchange.Exceptional.Shared/Internal/InternalExtensions.cs
+++ b/src/StackExchange.Exceptional.Shared/Internal/InternalExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace StackExchange.Exceptional.Internal
 {
@@ -319,5 +321,20 @@ namespace StackExchange.Exceptional.Internal
         /// </summary>
         /// <param name="dt">The <see cref="DateTime"/> to convert.</param>
         public static long? ToEpochTime(this DateTime? dt) => dt.HasValue ? (long?)ToEpochTime(dt.Value) : null;
+
+        private static readonly ConcurrentDictionary<string, Regex> _regexCache = new ConcurrentDictionary<string, Regex>();
+
+        /// <summary>
+        /// Replaces a QueryString token with the repalcement value.
+        /// </summary>
+        /// <param name="queryString">The querystring to operate on.</param>
+        /// <param name="key">The key to look for.</param>
+        /// <param name="value">The value to replace.</param>
+        /// <returns>The updated query string.</returns>
+        public static string QueryStringReplace(this string queryString, string key, string value)
+        {
+            var regex = _regexCache.GetOrAdd(key, k => new Regex("(?<=[?&]" + Regex.Escape(k) + "=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled));
+            return regex.Replace(queryString, value);
+        }
     }
 }

--- a/src/StackExchange.Exceptional/AspNetExtensions.cs
+++ b/src/StackExchange.Exceptional/AspNetExtensions.cs
@@ -1,10 +1,8 @@
 ﻿using StackExchange.Exceptional.Internal;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 
@@ -132,8 +130,6 @@ namespace StackExchange.Exceptional
             }
         }
 
-        private static readonly ConcurrentDictionary<string, Regex> _regexCache = new ConcurrentDictionary<string, Regex>();
-
         /// <summary>
         /// Sets Error properties pulled from HttpContext, if present.
         /// </summary>
@@ -224,8 +220,7 @@ namespace StackExchange.Exceptional
                 var newQuery = oldQuery;
                 foreach (var kv in queryFilters)
                 {
-                    var regex = _regexCache.GetOrAdd(kv.Key, key => new Regex("(?<=[?&]" + Regex.Escape(key) + "=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled));
-                    newQuery = regex.Replace(newQuery, kv.Value);
+                    newQuery = newQuery.QueryStringReplace(kv.Key, kv.Value);
                     if (error.QueryString[kv.Key] != null)
                     {
                         error.QueryString[kv.Key] = kv.Value ?? "";

--- a/src/StackExchange.Exceptional/AspNetExtensions.cs
+++ b/src/StackExchange.Exceptional/AspNetExtensions.cs
@@ -210,9 +210,22 @@ namespace StackExchange.Exceptional
             }
 
             error.ServerVariables = TryGetCollection(r => r.ServerVariables, ShouldRecordServerVariable);
-            error.QueryString = TryGetCollection(r => r.QueryString);
-            error.Form = TryGetCollection(r => r.Form);
 
+            error.QueryString = TryGetCollection(r => r.QueryString);
+            // Filter query variables for sensitive information
+            var queryFilters = error.Settings.LogFilters.QueryString;
+            if (queryFilters?.Count > 0)
+            {
+                foreach (var kv in queryFilters)
+                {
+                    if (error.QueryString[kv.Key] != null)
+                    {
+                        error.QueryString[kv.Key] = kv.Value ?? "";
+                    }
+                }
+            }
+
+            error.Form = TryGetCollection(r => r.Form);
             // Filter form variables for sensitive information
             var formFilters = error.Settings.LogFilters.Form;
             if (formFilters?.Count > 0)

--- a/src/StackExchange.Exceptional/ConfigSettings.cs
+++ b/src/StackExchange.Exceptional/ConfigSettings.cs
@@ -138,6 +138,8 @@ namespace StackExchange.Exceptional
             public SettingsCollection<LogFilter> CookieFilters => this["Cookies"] as SettingsCollection<LogFilter>;
             [ConfigurationProperty("Headers")]
             public SettingsCollection<LogFilter> HeaderFilters => this["Headers"] as SettingsCollection<LogFilter>;
+            [ConfigurationProperty("QueryString")]
+            public SettingsCollection<LogFilter> QueryStringFilters => this["QueryString"] as SettingsCollection<LogFilter>;
 
             internal void Populate(ExceptionalSettings settings)
             {
@@ -153,6 +155,10 @@ namespace StackExchange.Exceptional
                 foreach (LogFilter h in HeaderFilters)
                 {
                     s.Header[h.Name] = h.ReplaceWith;
+                }
+                foreach (LogFilter h in QueryStringFilters)
+                {
+                    s.QueryString[h.Name] = h.ReplaceWith;
                 }
             }
 

--- a/tests/StackExchange.Exceptional.Tests.AspNetCore/Configs/Full.json
+++ b/tests/StackExchange.Exceptional.Tests.AspNetCore/Configs/Full.json
@@ -22,6 +22,9 @@
       },
       "Header": {
         "Accept-Language": "*********"
+      },
+      "QueryString": {
+        "queryToken": "**no tokens saved! pheww**"
       }
     },
     "Ignore": {

--- a/tests/StackExchange.Exceptional.Tests.AspNetCore/Configuration.cs
+++ b/tests/StackExchange.Exceptional.Tests.AspNetCore/Configuration.cs
@@ -58,6 +58,9 @@ namespace StackExchange.Exceptional.Tests.AspNetCore
             Assert.Single(settings.LogFilters.Header);
             Assert.Equal("*********", settings.LogFilters.Header["Accept-Language"]);
             Assert.Equal("*********", settings.LogFilters.Header["ACCEPT-language"]);
+            Assert.Single(settings.LogFilters.QueryString);
+            Assert.Equal("**no tokens saved! pheww**", settings.LogFilters.QueryString["queryToken"]);
+            Assert.Equal("**no tokens saved! pheww**", settings.LogFilters.QueryString["QUERYToken"]);
 
             // Email
             Assert.NotNull(settings.Email);

--- a/tests/StackExchange.Exceptional.Tests.AspNetCore/LogFilters.cs
+++ b/tests/StackExchange.Exceptional.Tests.AspNetCore/LogFilters.cs
@@ -58,6 +58,7 @@ namespace StackExchange.Exceptional.Tests.AspNetCore
                 Assert.Equal("***3", error.Form["FormSecret"]);
 
                 Assert.Equal(2, error.QueryString.Count);
+                Assert.EndsWith("?QueryNotSecret=QueryNotSecretValue&QuerySecret=***5", error.FullUrl);
                 Assert.Equal("QueryNotSecretValue", error.QueryString["QueryNotSecret"]);
                 Assert.Equal("***5", error.QueryString["QuerySecret"]);
             }

--- a/tests/StackExchange.Exceptional.Tests.AspNetCore/LogFilters.cs
+++ b/tests/StackExchange.Exceptional.Tests.AspNetCore/LogFilters.cs
@@ -26,8 +26,9 @@ namespace StackExchange.Exceptional.Tests.AspNetCore
                 CurrentSettings.LogFilters.Header["HeaderSecret"] = "***2";
                 CurrentSettings.LogFilters.Form["FormSecret"] = "***3";
                 CurrentSettings.LogFilters.Header["HeaderSecret-CaseTest"] = "***4";
+                CurrentSettings.LogFilters.QueryString["QuerySECRET"] = "***5"; // testing insensitivity too
 
-                var request = server.CreateRequest("/");
+                var request = server.CreateRequest("/?QueryNotSecret=QueryNotSecretValue&QuerySecret=dontlogme");
                 request.AddHeader("Cookie", "CookieNotSecret=CookieNotSecretValue; CookieSecret=secretcookie!;");
                 request.AddHeader("HeaderNotSecret", "HeaderNotSecretValue");
                 request.AddHeader("HeaderSecret", "secret header!");
@@ -55,6 +56,10 @@ namespace StackExchange.Exceptional.Tests.AspNetCore
                 Assert.Equal(2, error.Form.Count);
                 Assert.Equal("FormNotSecretValue", error.Form["FormNotSecret"]);
                 Assert.Equal("***3", error.Form["FormSecret"]);
+
+                Assert.Equal(2, error.QueryString.Count);
+                Assert.Equal("QueryNotSecretValue", error.QueryString["QueryNotSecret"]);
+                Assert.Equal("***5", error.QueryString["QuerySecret"]);
             }
         }
     }


### PR DESCRIPTION
This adds query string parsing for both the name value collection and the string version (this unfortunately differs slightly between ASP.NET and ASP.NET Core).

The reason for using regex here is to minimally change the query string - e.g. "what if that's the reason we errored in the first place?" So, a simple light-touch replacement is intentional.