### PR TITLE
Fix app name config for ASP.NET Core

### DIFF
--- a/docs/AspDotNetCore.md
+++ b/docs/AspDotNetCore.md
@@ -22,7 +22,7 @@ public void ConfigureServices(IServiceCollection services)
     // This uses all defaults (e.g. the in-memory error store)
     services.AddExceptional(settings =>
     {
-        settings.ApplicationName = "Samples.AspNetCore";
+        settings.Store.ApplicationName = "Samples.AspNetCore";
     });
 }
 ```


### PR DESCRIPTION
Noticed a minor issue with the `ApplicationName` config option in the Core docs.