### PR TITLE
IStartupFilter for capturing .Configure() errors

### DIFF
--- a/samples/Samples.AspNetCore/Startup.cs
+++ b/samples/Samples.AspNetCore/Startup.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Exceptional;
 
 namespace Samples.AspNetCore
 {
@@ -31,6 +33,7 @@ namespace Samples.AspNetCore
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app)
         {
+            new Exception("Startup test exception - see how I'm captured! This happens due to a pre-.Configure() IStartupFilter").LogNoContext();
             // Boilerplate we're no longer using with Exceptional
             //if (env.IsDevelopment())
             //{

--- a/src/StackExchange.Exceptional.AspNetCore/ExceptionalServiceExtensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/ExceptionalServiceExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using StackExchange.Exceptional;
 using System;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -18,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddExceptional(this IServiceCollection services, IConfiguration config, Action<ExceptionalSettings> configureSettings = null)
         {
             services.Configure<ExceptionalSettings>(config.Bind); // Custom extension
+            services.AddTransient<IStartupFilter, ExceptionalStartupFilter>();
             return AddExceptional(services, configureSettings);
         }
 
@@ -35,6 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // When done configuring, set the background settings object for non-context logging.
             services.Configure<ExceptionalSettings>(Exceptional.Configure);
+            services.AddTransient<IStartupFilter, ExceptionalStartupFilter>();
 
             return services;
         }

--- a/src/StackExchange.Exceptional.AspNetCore/ExceptionalServiceExtensions.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/ExceptionalServiceExtensions.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddExceptional(this IServiceCollection services, IConfiguration config, Action<ExceptionalSettings> configureSettings = null)
         {
             services.Configure<ExceptionalSettings>(config.Bind); // Custom extension
-            services.AddTransient<IStartupFilter, ExceptionalStartupFilter>();
             return AddExceptional(services, configureSettings);
         }
 
@@ -37,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // When done configuring, set the background settings object for non-context logging.
             services.Configure<ExceptionalSettings>(Exceptional.Configure);
-            services.AddTransient<IStartupFilter, ExceptionalStartupFilter>();
+            services.AddTransient<IStartupFilter, ExceptionalStartupFilter>(); // Note: transient is how all framework IStartupFilters are registered
 
             return services;
         }

--- a/src/StackExchange.Exceptional.AspNetCore/ExceptionalStartupFilter.cs
+++ b/src/StackExchange.Exceptional.AspNetCore/ExceptionalStartupFilter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace StackExchange.Exceptional
+{
+    internal class ExceptionalStartupFilter : IStartupFilter
+    {   
+        /// <summary>
+        /// Configures exceptional early on, as to catch any errors that happen in Startup.Configure (or equivalent).
+        /// </summary>
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) =>
+            builder =>
+            {
+                // Touch settings so that we initialize early
+                _ = builder.ApplicationServices.GetService<IOptions<ExceptionalSettings>>().Value;
+                next(builder);
+            };
+    }
+}

--- a/tests/StackExchange.Exceptional.Tests.AspNetCore/StartupFilter.cs
+++ b/tests/StackExchange.Exceptional.Tests.AspNetCore/StartupFilter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using StackExchange.Exceptional.Stores;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Exceptional.Tests.AspNetCore
+{
+    [Collection(NonParallel)]
+    public class StartupFilter : AspNetCoreTest
+    {
+        public StartupFilter(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public async Task CapturesStartupError()
+        {
+            var startupEx = Assert.Throws<Exception>(() => new TestServer(
+                    new WebHostBuilder()
+                        .SuppressStatusMessages(true) // Prevent log spam in tests
+                        .ConfigureServices(services => services.AddExceptional(s =>
+                        {
+                            s.DefaultStore = new MemoryErrorStore();
+                            CurrentSettings = s;
+                        }))
+                        .Configure(app =>
+                        {
+                            new Exception("Startup log").LogNoContext();
+                            throw new Exception("A-a-a-a-a-a-app killer!");
+                            // Unreachable code...
+                            //app.UseExceptional();
+                            //app.Run(r => throw new Exception("Log me!"));
+                        })));
+            
+            Assert.Equal("A-a-a-a-a-a-app killer!", startupEx.Message);
+
+            var errors = await GetErrorsAsync();
+            // When we hook up ILogger<WebHost>, we can capture non-direct logs in .Configure() here:
+            // https://github.com/dotnet/aspnetcore/blob/01e05359d644a1f68c1e26a196fc3370ec9ded49/src/Hosting/Hosting/src/Internal/WebHost.cs#L234-L240
+            Assert.Single(errors);
+            Assert.Equal("Startup log", errors[0].Message);
+            //Assert.Equal("A-a-a-a-a-a-app killer!", errors[1].Message);
+        }
+    }
+}


### PR DESCRIPTION
This should solve the problem of a not-yet-configured Exceptional when we're inside .Configure(). Until the first time the settings are resolved, we don't do the configuration, so the solution here is to cause said resolution ahead of app configuration.

Given we're adding `ExceptionalSettings` at the same time as we're adding the `IStartupFilter`, I think we're safe to assume it's always there. Thoughts @deanward81? I flip/flopped on null checking and `.GetRequiredService` here, curious whatcha think.