### PR TITLE
Update MySqlConnector to version 1.2.0.  Fix usings to use new namespace.

### DIFF
--- a/src/StackExchange.Exceptional.MySQL/MySQLErrorStore.cs
+++ b/src/StackExchange.Exceptional.MySQL/MySQLErrorStore.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using StackExchange.Exceptional.Internal;
 
 namespace StackExchange.Exceptional.Stores

--- a/src/StackExchange.Exceptional.MySQL/StackExchange.Exceptional.MySQL.csproj
+++ b/src/StackExchange.Exceptional.MySQL/StackExchange.Exceptional.MySQL.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <ProjectReference Include="..\StackExchange.Exceptional.Shared\StackExchange.Exceptional.Shared.csproj" />
     <PackageReference Include="Dapper" Version="1.50.2" />
-    <PackageReference Include="MySqlConnector" Version="0.60.2" />
+    <PackageReference Include="MySqlConnector" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/tests/StackExchange.Exceptional.Tests/Storage/MySQLErrorStoreTest.cs
+++ b/tests/StackExchange.Exceptional.Tests/Storage/MySQLErrorStoreTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using StackExchange.Exceptional.Stores;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
I'm not 100% sure if this will work, I'm not able to run the tests on my machine.

This might also cause other issues if trying to use MySqlConnector < 1.0.0.  Is there a way in a config to change the namespace of a type?

https://mysqlconnector.net/overview/version-history/

