### PR TITLE
Update Global.asax.cs

### DIFF
--- a/samples/Samples.MVC5/Global.asax.cs
+++ b/samples/Samples.MVC5/Global.asax.cs
@@ -31,7 +31,6 @@ namespace Samples.MVC5
                 settings.GetCustomData = (exception, data) =>
                 {
                     // exception is the exception thrown
-                    // context is the HttpContext of the request (could be null, e.g. background thread exception)
                     // data is a Dictionary<string, string> to add custom data too
                     data.Add("Example string", DateTime.UtcNow.ToString());
                     data.Add("User Id", "You could fetch a user/account Id here, etc.");


### PR DESCRIPTION
I removed the comment reference that remained to context because HttpContext is no longer available. (I discovered this because I actually wanted to use HttpContext in my custom data setup to log HttpReferrer).