### PR TITLE
HtmlEncode table keys when showing details

### DIFF
--- a/src/StackExchange.Exceptional.Shared/Internal/ErrorEmail.cs
+++ b/src/StackExchange.Exceptional.Shared/Internal/ErrorEmail.cs
@@ -38,7 +38,7 @@ namespace StackExchange.Exceptional.Internal
                         {
                             continue;
                         }
-                        sb.AppendFormat("      <tr{2}><td style=\"padding: 0.4em; width: 200px;\">{0}</td><td style=\"padding: 0.4em;\">{1}</td></tr>", k, Linkify(vars[k]), getBackground()).AppendLine();
+                        sb.AppendFormat("      <tr{2}><td style=\"padding: 0.4em; width: 200px;\">{0}</td><td style=\"padding: 0.4em;\">{1}</td></tr>", k.HtmlEncode(), Linkify(vars[k]), getBackground()).AppendLine();
                     }
                     if (renderUrls && vars["Request Method"].IsNullOrEmpty()) // told to render and we don't have them elsewhere
                     {

--- a/src/StackExchange.Exceptional.Shared/Pages/ErrorDetailPage.cs
+++ b/src/StackExchange.Exceptional.Shared/Pages/ErrorDetailPage.cs
@@ -68,7 +68,7 @@ namespace StackExchange.Exceptional.Pages
                         if (vars[k].HasValue())
                         {
                             // If this is a hidden row, buffer it up, since CSS has no clean mechanism for :visible:nth-row(odd) type styling behavior
-                            (DefaultHttpKeys.Contains(k) ? hiddenRows : sb).AppendFormat("        <tr><td>{0}</td><td>{1}</td></tr>", k, Linkify(vars[k])).AppendLine();
+                            (DefaultHttpKeys.Contains(k) ? hiddenRows : sb).AppendFormat("        <tr><td>{0}</td><td>{1}</td></tr>", k.HtmlEncode(), Linkify(vars[k])).AppendLine();
                         }
                     }
                     if (renderUrls && vars["Request Method"].IsNullOrEmpty()) // told to render and we don't have them elsewhere


### PR DESCRIPTION
Escape the element's key as well as its content.